### PR TITLE
Add test coverage for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
For future-proofing, test that `Ergate` runs correctly in Python 3.13 and 3.14 environments.  (If not, then `pyproject.toml` should be modified to restrict `requires-python` to `>=3.10, <3.13`.)

Also, fix some grammatical mistakes in the workflow.